### PR TITLE
Implement a fully customizable configuration for many example targets

### DIFF
--- a/src/main/kotlin/RustPlugin.kt
+++ b/src/main/kotlin/RustPlugin.kt
@@ -29,6 +29,7 @@ import asia.hombre.neorust.options.RustBinaryOptions.Binary
 import asia.hombre.neorust.options.RustBuildOptions
 import asia.hombre.neorust.options.RustBuildTargetOptions
 import asia.hombre.neorust.options.RustCrateOptions
+import asia.hombre.neorust.options.RustExamplesOptions
 import asia.hombre.neorust.options.RustFeaturesOptions
 import asia.hombre.neorust.options.RustLibraryOptions
 import asia.hombre.neorust.options.RustManifestOptions
@@ -221,6 +222,24 @@ fun RustExtension.binary(binaryConfig: Action<RustBinariesOptions>) {
     binary.isEnabled = true
     this.rustBinariesOptions.add(binary)
 }
+
+/**
+ * Configure a new example Cargo target
+ */
+@Suppress("unused")
+fun RustExtension.example(exampleConfig: Action<RustExamplesOptions>) {
+    val example = objects.newInstance(RustExamplesOptions::class.java)
+
+    exampleConfig.execute(example)
+
+    if(this.rustExamplesOptions.any { it.name.orNull == example.name.orNull }) {
+        throw IllegalArgumentException("`example {}` parameter `name` must be unique! ${example.name.orNull} has already been declared.")
+    }
+
+    example.isEnabled = true
+    this.rustExamplesOptions.add(example)
+}
+
 
 /**
  * Register a binary target to be built and configure it for custom builds

--- a/src/main/kotlin/asia/hombre/neorust/Rust.kt
+++ b/src/main/kotlin/asia/hombre/neorust/Rust.kt
@@ -116,6 +116,7 @@ class Rust: Plugin<Project> {
                 rustFeaturesOptions.set(extension.rustFeaturesOptions)
                 rustLibraryOptions.set(extension.rustLibraryOptions)
                 rustBinariesOptions.set(extension.rustBinariesOptions)
+                rustExamplesOptions.set(extension.rustExamplesOptions)
                 this.crateLibrary.set(crateLibrary)
                 featuresList.set(extension.featuresList)
                 manifestPath.set(extension.manifestPath)

--- a/src/main/kotlin/asia/hombre/neorust/extension/RustExtension.kt
+++ b/src/main/kotlin/asia/hombre/neorust/extension/RustExtension.kt
@@ -24,6 +24,7 @@ import asia.hombre.neorust.options.RustBinariesOptions
 import asia.hombre.neorust.options.RustBinaryOptions
 import asia.hombre.neorust.options.RustBuildOptions
 import asia.hombre.neorust.options.RustBuildTargetOptions
+import asia.hombre.neorust.options.RustExamplesOptions
 import asia.hombre.neorust.options.RustFeaturesOptions
 import asia.hombre.neorust.options.RustLibraryOptions
 import asia.hombre.neorust.options.RustManifestOptions
@@ -203,7 +204,8 @@ abstract class RustExtension @Inject constructor(project: Project) {
     internal val rustLibraryOptions: RustLibraryOptions = objects.newInstance(
         RustLibraryOptions::class.java
     )
-
     @Internal
     internal val rustBinariesOptions: MutableList<RustBinariesOptions> = mutableListOf()
+    @Internal
+    internal val rustExamplesOptions: MutableList<RustExamplesOptions> = mutableListOf()
 }

--- a/src/main/kotlin/asia/hombre/neorust/options/RustExamplesOptions.kt
+++ b/src/main/kotlin/asia/hombre/neorust/options/RustExamplesOptions.kt
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2025 Ron Lauren Hombre (and the neo-rust-gradle-plugin contributors)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *        and included as LICENSE.txt in this Project.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package asia.hombre.neorust.options
+
+import javax.inject.Inject
+
+/**
+ * Customizable configuration for any Rust example target
+ *
+ * @since 0.6.0
+ * @author Ron Lauren Hombre
+ */
+abstract class RustExamplesOptions @Inject constructor(): RustTargetOptions() {
+    init {
+        //Examples are always the "bin" crate type
+        //https://doc.rust-lang.org/cargo/reference/cargo-targets.html#:~:text=Binaries%2C%20tests%2C%20and%20benchmarks%20are%20always%20the%20%E2%80%9Cbin%E2%80%9D%20crate%20type.
+        this.crateType.finalizeValue()
+        path.convention(
+            project
+                .layout
+                .projectDirectory
+                .dir("src")
+                .dir("main")
+                .dir("rust")
+                .dir("examples")
+                .file("main.rs")
+        )
+    }
+
+    /**
+     * Attempts to resolve a `.rs` file as the `path` for this Cargo target.
+     *
+     * The file will be searched in directory `src/main/rust/examples/` of this Gradle project.
+     *
+     * So if you do `resolve("example.rs")`, it will be internally resolved as `src/main/rust/examples/example.rs`. This
+     * makes it extremely easy to define multiple example targets.
+     *
+     * It is also possible to do `resolve("bin", "client.rs")`, and this will be resolved as
+     * `src/main/rust/examples/bin/client.rs`.
+     *
+     * @param paths A list of arguments defining the location of the main file for this binary Cargo target.
+     * @return `true` if the file exists in the path and has been applied, `false` otherwise.
+     */
+    override fun resolve(vararg paths: String): Boolean {
+        return super.resolve("examples", *paths)
+    }
+}

--- a/src/main/kotlin/asia/hombre/neorust/options/RustTargetOptions.kt
+++ b/src/main/kotlin/asia/hombre/neorust/options/RustTargetOptions.kt
@@ -92,7 +92,7 @@ abstract class RustTargetOptions @Inject constructor() {
      * @param paths A list of arguments defining the location of the main file for this binary Cargo target.
      * @return `true` if the file exists in the path and has been applied, `false` otherwise.
      */
-    fun resolve(vararg paths: String): Boolean {
+    open fun resolve(vararg paths: String): Boolean {
         var currentDirectory = project
             .layout
             .projectDirectory

--- a/src/main/kotlin/asia/hombre/neorust/task/CargoManifestGenerate.kt
+++ b/src/main/kotlin/asia/hombre/neorust/task/CargoManifestGenerate.kt
@@ -21,6 +21,7 @@ package asia.hombre.neorust.task
 import asia.hombre.neorust.CrateLibrary
 import asia.hombre.neorust.options.RustBinariesOptions
 import asia.hombre.neorust.options.RustCrateOptions
+import asia.hombre.neorust.options.RustExamplesOptions
 import asia.hombre.neorust.options.RustFeaturesOptions
 import asia.hombre.neorust.options.RustLibraryOptions
 import asia.hombre.neorust.options.RustManifestOptions
@@ -70,6 +71,8 @@ abstract class CargoManifestGenerate @Inject constructor(): DefaultTask() {
     internal abstract val rustLibraryOptions: Property<RustLibraryOptions>
     @get:Nested
     internal abstract val rustBinariesOptions: ListProperty<RustBinariesOptions>
+    @get:Nested
+    internal abstract val rustExamplesOptions: ListProperty<RustExamplesOptions>
 
     @get:Input
     internal abstract val featuresList: MapProperty<String, List<String>>
@@ -280,6 +283,24 @@ abstract class CargoManifestGenerate @Inject constructor(): DefaultTask() {
                 //The user can't modify this, so we ignore it
                 //writeArrayField("crate-type", binary.crateType.get())
                 writeArrayField("required-features", binary.requiredFeatures.get())
+            }
+        }
+
+        val rustExamplesOptions = rustExamplesOptions.get()
+
+        rustExamplesOptions.forEach { example ->
+            content.writeTable("[example]") {
+                writeField("name", example.name.orNull)
+                writeField("path", example.path.get().relativeToManifest(cargoToml))
+                writeBooleanField("test", example.test.orNull)
+                writeBooleanField("doctest", example.doctest.orNull)
+                writeBooleanField("bench", example.bench.orNull)
+                writeBooleanField("doc", example.doc.orNull)
+                writeBooleanField("procMacro", example.procMacro.orNull)
+                writeBooleanField("harness", example.harness.orNull)
+                //The user can't modify this, so we ignore it
+                //writeArrayField("crate-type", example.crateType.get())
+                writeArrayField("required-features", example.requiredFeatures.get())
             }
         }
 


### PR DESCRIPTION
- Removed old implementation
- Override `resolve()` to resolve inside `examples` directory

Fixes #5.