### PR TITLE
Disable auto-discovery since we're not following standard Rust project structure

### DIFF
--- a/src/main/kotlin/asia/hombre/neorust/options/RustManifestOptions.kt
+++ b/src/main/kotlin/asia/hombre/neorust/options/RustManifestOptions.kt
@@ -107,17 +107,5 @@ abstract class RustManifestOptions @Inject constructor(objectFactory: ObjectFact
         @get:Input
         @get:Optional
         abstract val defaultRun: Property<String>
-        @get:Input
-        @get:Optional
-        abstract val autoBins: Property<Boolean>
-        @get:Input
-        @get:Optional
-        abstract val autoExamples: Property<Boolean>
-        @get:Input
-        @get:Optional
-        abstract val autoTests: Property<Boolean>
-        @get:Input
-        @get:Optional
-        abstract val autoBenches: Property<Boolean>
     }
 }

--- a/src/main/kotlin/asia/hombre/neorust/task/CargoManifestGenerate.kt
+++ b/src/main/kotlin/asia/hombre/neorust/task/CargoManifestGenerate.kt
@@ -185,14 +185,13 @@ abstract class CargoManifestGenerate @Inject constructor(): DefaultTask() {
 
             if(packageOptions.defaultRun.isPresent)
                 writeField("default-run", packageOptions.defaultRun.get())
-            if(packageOptions.autoBins.isPresent)
-                writeBooleanField("autobins", packageOptions.autoBins.get())
-            if(packageOptions.autoExamples.isPresent)
-                writeBooleanField("autoexamples", packageOptions.autoExamples.get())
-            if(packageOptions.autoTests.isPresent)
-                writeBooleanField("autotests", packageOptions.autoTests.get())
-            if(packageOptions.autoBenches.isPresent)
-                writeBooleanField("autobenches", packageOptions.autoBenches.get())
+
+            //Disable auto-discovery since we violate the standard Rust directory structure anyway
+            writeBooleanField("autolib", false)
+            writeBooleanField("autobins", false)
+            writeBooleanField("autoexamples", false)
+            writeBooleanField("autotests", false)
+            writeBooleanField("autobenches", false)
         }
 
         if(rustProfileOptions.get().dev.get().isNotEmpty()) content.writeTable("profile.dev") {


### PR DESCRIPTION
Fixes #8.