### PR TITLE
Add documentation for Cargo enum values

### DIFF
--- a/src/main/kotlin/asia/hombre/neorust/option/CargoMessageFormat.kt
+++ b/src/main/kotlin/asia/hombre/neorust/option/CargoMessageFormat.kt
@@ -5,9 +5,9 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *        https://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
- *        and included as LICENSE.txt in this Project.
+ * and included as LICENSE.txt in this Project.
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -24,4 +24,34 @@ package asia.hombre.neorust.option
  * @since 0.1.0
  * @author Ron Lauren Hombre
  */
-enum class CargoMessageFormat { human, short, json, json_diagnostic_short, json_diagnostic_rendered_ansi, json_render_diagnostics }
+enum class CargoMessageFormat {
+    /**
+     * Displays messages in a human-readable text format. This is the default.
+     */
+    human,
+
+    /**
+     * Emits shorter, human-readable text messages.
+     */
+    short,
+
+    /**
+     * Emits JSON messages to stdout.
+     */
+    json,
+
+    /**
+     * Ensures the rendered field of JSON messages contains the "short" rendering from rustc.
+     */
+    json_diagnostic_short,
+
+    /**
+     * Ensures the rendered field of JSON messages contains embedded ANSI color codes for respecting rustc's default color scheme.
+     */
+    json_diagnostic_rendered_ansi,
+
+    /**
+     * Instructs Cargo to not include rustc diagnostics in JSON messages printed, but instead Cargo itself should render the JSON diagnostics coming from rustc.
+     */
+    json_render_diagnostics
+}

--- a/src/main/kotlin/asia/hombre/neorust/option/CargoTiming.kt
+++ b/src/main/kotlin/asia/hombre/neorust/option/CargoTiming.kt
@@ -5,9 +5,9 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *        https://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
- *        and included as LICENSE.txt in this Project.
+ * and included as LICENSE.txt in this Project.
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -24,4 +24,29 @@ package asia.hombre.neorust.option
  * @since 0.1.0
  * @author Ron Lauren Hombre
  */
-enum class CargoTiming { none, default, html, json, html_and_json }
+enum class CargoTiming {
+    /**
+     * Does not generate any timing report.
+     */
+    none,
+
+    /**
+     * Uses the default timing report format (equivalent to passing --timings without arguments).
+     */
+    default,
+
+    /**
+     * Writes a human-readable HTML report to the target/cargo-timings directory.
+     */
+    html,
+
+    /**
+     * Emits machine-readable timing information in JSON format.
+     */
+    json,
+
+    /**
+     * Generates both the HTML report and the JSON machine-readable data.
+     */
+    html_and_json
+}


### PR DESCRIPTION
This PR adds documentation comments to the CargoTiming and CargoMessageFormat enum values, as requested in issue #12.

The comments are based on the official Cargo documentation and aim to clarify the behavior of each option.

Closes #12 and Closes #13
