### PR TITLE
Generate build tasks for examples, tests, and benchmarks

### DIFF
--- a/src/main/kotlin/asia/hombre/neorust/internal/CargoDefaultTask.kt
+++ b/src/main/kotlin/asia/hombre/neorust/internal/CargoDefaultTask.kt
@@ -179,7 +179,7 @@ abstract class CargoDefaultTask @Inject constructor() : DefaultTask() {
 
         features.apply {
             if(isPresent && !allFeatures.getOrElse(false) && this@CargoDefaultTask !is CargoClean)
-                args.addAll(listOf("--features", get().joinToString(" ")))
+                args.addAll(listOf("--features", get().toSet().joinToString(" ")))
         }
 
         if(noDefaultFeatures.getOrElse(false) && this !is CargoClean)

--- a/src/main/kotlin/asia/hombre/neorust/options/targets/BinaryConfiguration.kt
+++ b/src/main/kotlin/asia/hombre/neorust/options/targets/BinaryConfiguration.kt
@@ -50,10 +50,6 @@ abstract class BinaryConfiguration @Inject constructor(): CargoTargetConfigurati
     @get:Optional
     abstract val environment: MapProperty<String, String>
 
-    @get:Input
-    @get:Optional
-    abstract val buildFeatures: ListProperty<String>
-
     init {
         //Binaries, Tests, Benchmarks, and Examples are always the "bin" crate type
         //https://doc.rust-lang.org/cargo/reference/cargo-targets.html#:~:text=Binaries%2C%20tests%2C%20and%20benchmarks%20are%20always%20the%20%E2%80%9Cbin%E2%80%9D%20crate%20type.

--- a/src/main/kotlin/asia/hombre/neorust/options/targets/CargoTargetConfiguration.kt
+++ b/src/main/kotlin/asia/hombre/neorust/options/targets/CargoTargetConfiguration.kt
@@ -80,6 +80,10 @@ abstract class CargoTargetConfiguration @Inject constructor() {
     @get:Input
     abstract val requiredFeatures: ListProperty<String>
 
+    @get:Input
+    @get:Optional
+    abstract val buildFeatures: ListProperty<String>
+
     @get:Internal
     var isEnabled = false
 

--- a/src/main/kotlin/asia/hombre/neorust/task/CargoBuild.kt
+++ b/src/main/kotlin/asia/hombre/neorust/task/CargoBuild.kt
@@ -21,6 +21,7 @@ package asia.hombre.neorust.task
 import asia.hombre.neorust.internal.CargoTargettedTask
 import asia.hombre.neorust.option.CargoMessageFormat
 import asia.hombre.neorust.option.CargoTiming
+import org.gradle.api.file.Directory
 import org.gradle.api.file.DirectoryProperty
 import org.gradle.api.provider.ListProperty
 import org.gradle.api.provider.Property
@@ -37,7 +38,7 @@ import javax.inject.Inject
  * @since 0.1.0
  * @author Ron Lauren Hombre
  */
-abstract class CargoBuild @Inject constructor(releaseBuild: Boolean): CargoTargettedTask() {
+abstract class CargoBuild @Inject constructor(): CargoTargettedTask() {
     @get:Input
     @get:Optional
     abstract val workspace: Property<Boolean>
@@ -72,10 +73,12 @@ abstract class CargoBuild @Inject constructor(releaseBuild: Boolean): CargoTarge
 
     init {
         outputTargetDirectory.convention(
-            if(releaseBuild) {
-                targetDirectory.dir("release")
-            } else {
-                targetDirectory.dir("debug")
+            project.provider<Directory> {
+                if(release.getOrElse(false)) {
+                    targetDirectory.dir("release")
+                } else {
+                    targetDirectory.dir("debug")
+                }.get()
             }
         )
     }


### PR DESCRIPTION
- Similar to binaries
- Added the target name to the build task to prevent a binary named "example" from conflicting with a test named "example". Now they both become BinaryExample and TestExample in the task names

Fixes #41.